### PR TITLE
"No-data export for:" message is confusing

### DIFF
--- a/src/DEG/Magento/Command/Database/ExportCommand.php
+++ b/src/DEG/Magento/Command/Database/ExportCommand.php
@@ -113,7 +113,7 @@ HELP;
             if (!$input->getOption('stdout') && !$input->getOption('only-command')
                 && !$input->getOption('print-only-filename')
             ) {
-                $output->writeln('<comment>No-data export for: <info>' . implode(' ', $includeTables)
+                $output->writeln('<comment>Exporting data and structure for: <info>' . implode(' ', $includeTables)
                     . '</info></comment>'
                 );
             }


### PR DESCRIPTION
I think this is a left-over from the original dump command. Here it's actually exactly these table that will be exported.

Btw, nice plugin! I was just about to write something like this when I discovered yours. I'll be using this one now instead.

Since this partial export isn't too different from the original db:dump command I was wondering if it wouldn't make sense to extend the original command allowing to specify the tables and have this part of n98-magerun. On the other hand too many options might get very confusing soon, so maybe it's good to keep that as a separate command (could still go into the core though...).

Also, I really like that you're also supporting the '@...' syntax.

Thank you,
Fabrizio
